### PR TITLE
Fix solace.spc to use `solacelabs` instead of `SolaceLabs`

### DIFF
--- a/config/solace.spc
+++ b/config/solace.spc
@@ -1,5 +1,5 @@
 connection "solace" {
-  plugin = "SolaceLabs/solace"
+  plugin = "solacelabs/solace"
 
   # Get your API key from https://console.solace.cloud/api-tokens
   # This can also be set via the `SOLACE_API_TOKEN` environment variable.


### PR DESCRIPTION
This plugin build process expects the plugin to use `solacelabs` instead of `SolaceLabs`.